### PR TITLE
Handle varchars used as bytearrays better by avoiding the unicode conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+
+# Copied in libraries
+src/dotNetCore.Data.OracleClient.Internal/lib-win-x64
+src/dotNetCore.Data.OracleClient.Internal/lib-linux-x64

--- a/src/dotNetCore.Data.OracleClient.Internal/README.md
+++ b/src/dotNetCore.Data.OracleClient.Internal/README.md
@@ -1,0 +1,98 @@
+# Company Internal NuGet Package
+
+## Purpose
+
+The purpose of this project is to generate a NuGet
+package which contains the shared Oracle InstantClient libraries. The
+benefit is that those libraries do not need to be installed as a separate
+step and also (in Windows) the PATH environment variable does not have
+to be set.
+
+The package may _not_ be posted publicly since it contains Oracle
+libraries and the license does not allow for that.
+That is, once you create the package, put it in your internal NuGet
+repository.
+
+This setup is to generate a package using the 11.x Instant Client libraries
+so that old, unsupported versions of Oracle can be accessed. If you want to
+use a different library version, you will need to alter the `.csproj` file.
+
+**If you are accessing Oracle 11+, consider
+ [The Official .NET Core Oracle Driver](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core).**
+
+## Caveats / Notes
+
+### Build on Linux
+
+* Git-Bash / Windows does not handle the executable bit, which needs to be set on the
+  .so files. If you are building for Linux/Mac + Windows, use a UNIX host for the build.
+
+* The source directories are also symbolic links to the main tree, which may or may not play
+  well with git-bash.
+
+* You will need the `patchelf` utility.
+
+### Linux Still Needs a Linker Path Set
+
+`libclntsh.so` depends on `libnnz11.so`. However, dotnet will only find the first library
+and let the OS link the second, which will fail since, by default, the linker does not look in the
+same directory where `libclntsh.so` is located (as part of the nuget package).
+
+To work around this, use `patchelf` to set the search path for the main shared-object library to
+be the same directory in which it is located:
+
+```bash
+patchelf --set-rpath '$ORIGIN/.' libclntsh.so
+```
+
+Note the use of single quotes here, it is very important that the `$ORIGIN` has the `$` in
+the string. [ld-linux man page](http://man7.org/linux/man-pages/man8/ld-linux.so.8.html)
+
+Mac users can do a similar thing with `install_name_tool` -- see https://stackoverflow.com/questions/13769141/can-i-change-rpath-in-an-already-compiled-binary
+
+## Building
+
+Download and unzip the InstantClient zip files for the Oracle version and OS
+you want to support. The files shown below are assuming version 11.x.
+
+Put the Windows DLLs into lib-win-x64:
+
+```bash
+mkdir lib-win-x64
+cp instantclient_11_2/oci.dll lib-win-x64
+cp instantclient_11_2/orannzsbb11.dll lib-win-x64
+cp instantclient_11_2/oraocci11.dll lib-win-x64
+cp instantclient_11_2/oraociei11.dll lib-win-x64
+```
+
+Put the Linux shared object files into lib-linux-x64. Note they
+must be renamed, and change the rpath of `libclntsh.so`:
+
+```bash
+mkdir lib-linux-x64
+cp instantclient_11_2/libclntsh.so.11.1 lib-linux-x64/libclntsh.so
+cp instantclient_11_2/libnnz11.so.11.1 lib-linux-x64/libnnz11.so
+patchelf --set-rpath '$ORIGIN/.' lib-linux-x64/libclntsh.so
+```
+
+Build the NuGet package:
+
+```bash
+dotnet pack -c Release
+```
+
+Copy the package to your local NuGet repository:
+
+```bash
+cp bin/Release/dotNetCore.Data.OracleClient.Internal.1.0.1.nupkg /path/to/local/NuGet/repo
+```
+
+Finally, you can add the package to your project:
+
+```bash
+dotnet add package dotNetCore.Data.OracleClient11.Internal
+```
+
+END
+
+[//]: # ( spell-checker:ignore patchelf libclntsh libnnz nuget rpath mkdir instantclient orannzsbb oraocci oraociei nupkg repo )

--- a/src/dotNetCore.Data.OracleClient.Internal/dotNetCore.Data.OracleClient.Internal.csproj
+++ b/src/dotNetCore.Data.OracleClient.Internal/dotNetCore.Data.OracleClient.Internal.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>dotNetCore.Data.OracleClient11.Internal</PackageId>
+    <Product>oracleClientCore-2.0</Product>
+    <PackageVersion>1.0.1</PackageVersion>
+    <Authors>Eric Mendonca</Authors>
+    <PackageProjectUrl>https://github.com/ericmend/oracleClientCore-2.0</PackageProjectUrl>
+    <Description>
+      Unofficial Oracle Client for .Net Core.
+      
+      For company internal use only since the NuGet package contains the shared object libraries from Oracle.
+    </Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>
+      1.0.1
+      - Pack native DLLs for internal NuGet
+
+      1.0.0
+      - Providing the unofficial oracle client as nuget
+      </PackageReleaseNotes>
+    <Copyright>Copyright 2017</Copyright>
+    <PackageTags>Client Oracle Core oracleClientCore</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../dotNetCore.Data.OracleClient/System.Data.OracleClient/*.cs" />
+    <Compile Include="../dotNetCore.Data.OracleClient/System.Data.OracleClient.Oci/*.cs" />
+    <Compile Include="../dotNetCore.Data.OracleClient/System.Data.OracleClient.Oci/OciNativeCalls/*.cs" />
+  </ItemGroup>
+
+  <Target Name="SharedLibTarget" AfterTargets="Build">
+    <Copy SourceFiles="@(MyPackageFiles)" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  </Target>
+
+<!-- Just incude everything found, no errors for missing files.
+  <ItemGroup>
+    <None Include="./lib-win-x64/*.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <None Include="./lib-linux-x64/*.so*" Pack="true" PackagePath="runtimes/linux-x64/native" />
+  </ItemGroup>
+-->
+
+<!-- Alternative way, will also raise an error if a needed file is missing -->
+  <ItemGroup>
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-win-x64/oci.dll" Link="oci.dll" Pack="true" PackagePath="runtimes/win-x64/native/oci.dll" />
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-win-x64/orannzsbb11.dll" Link="orannzsbb11.dll" Pack="true" PackagePath="runtimes/win-x64/native/orannzsbb11.dll" />
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-win-x64/oraocci11.dll" Link="oraocci11.dll" Pack="true" PackagePath="runtimes/win-x64/native/oraocci11.dll" />
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-win-x64/oraociei11.dll" Link="oraociei11.dll" Pack="true" PackagePath="runtimes/win-x64/native/oraociei11.dll" />
+
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-linux-x64/libclntsh.so" Link="libclntsh.so" Pack="true" PackagePath="runtimes/linux-x64/native/libclntsh.so" />
+    <Content CopyToOutputDirectory="PreserveNewest" Include="lib-linux-x64/libnnz11.so" Link="libnnz11.so" Pack="true" PackagePath="runtimes/linux-x64/native/libnnz11.so" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotNetCore.Data.OracleClient/System.Data.OracleClient.Oci/OciDefineHandle.cs
+++ b/src/dotNetCore.Data.OracleClient/System.Data.OracleClient.Oci/OciDefineHandle.cs
@@ -533,6 +533,61 @@ namespace System.Data.OracleClient.Oci
             return new OracleLob(lobLocator, ociType);
         }
 
+        internal object GetValueByteArray(OracleConnection conn)
+        {
+
+            byte[] buffer = null;
+
+            switch (DataType)
+            {
+                case OciDataType.VarChar2:
+                case OciDataType.String:
+                case OciDataType.VarChar:
+                case OciDataType.Char:
+                case OciDataType.CharZ:
+                case OciDataType.OciString:
+                case OciDataType.RowIdDescriptor:
+                case OciDataType.Integer:
+                case OciDataType.Number:
+                case OciDataType.Float:
+                case OciDataType.VarNum:
+                case OciDataType.UnsignedInt:
+                case OciDataType.Date:
+                case OciDataType.Raw:
+                case OciDataType.VarRaw:
+                case OciDataType.TimeStamp:
+                case OciDataType.IntervalDayToSecond:
+                case OciDataType.IntervalYearToMonth:
+                    buffer = new byte[Size];
+                    Marshal.Copy(Value, buffer, 0, Size);
+                    return buffer;
+                case OciDataType.LongVarChar:
+                case OciDataType.Long:
+                    buffer = new byte[LongVarCharMaxValue];
+                    Marshal.Copy(Value, buffer, 0, buffer.Length);
+                    return buffer;
+                case OciDataType.LongRaw:
+                case OciDataType.LongVarRaw:
+                    buffer = new byte[LongVarRawMaxValue];
+                    Marshal.Copy(Value, buffer, 0, buffer.Length);
+
+                    int longrawSize = 0;
+                    if (BitConverter.IsLittleEndian)
+                        longrawSize = BitConverter.ToInt32(new byte[] { buffer[0], buffer[1], buffer[2], buffer[3] }, 0);
+                    else
+                        longrawSize = BitConverter.ToInt32(new byte[] { buffer[3], buffer[2], buffer[1], buffer[0] }, 0);
+
+                    byte[] longraw_buffer = new byte[longrawSize];
+                    Array.ConstrainedCopy(buffer, 4, longraw_buffer, 0, longrawSize);
+                    return longraw_buffer;
+                case OciDataType.Blob:
+                case OciDataType.Clob:
+                    return GetOracleLob();
+                default:
+                    throw new Exception("OciDataType not implemented: " + DataType.ToString());
+            }
+        }
+
         internal object GetValue(IFormatProvider formatProvider, OracleConnection conn)
         {
             object tmp;

--- a/src/dotNetCore.Data.OracleClient/System.Data.OracleClient/OracleDataReader.cs
+++ b/src/dotNetCore.Data.OracleClient/System.Data.OracleClient/OracleDataReader.cs
@@ -193,7 +193,7 @@ namespace System.Data.OracleClient
         override
         long GetBytes(int i, long fieldOffset, byte[] buffer2, int bufferoffset, int length)
         {
-            byte[] value = (byte[])GetValue(i);
+            byte[] value = (byte[])GetValueByteArray(i);
 
             if (buffer2 == null)
                 return value.Length; // Return length of data
@@ -320,7 +320,7 @@ namespace System.Data.OracleClient
             if (IsDBNull(i))
                 throw new InvalidOperationException("The value is null");
 
-            return new OracleBinary((byte[])GetValue(i));
+            return new OracleBinary((byte[])GetValueByteArray(i));
         }
 
         public OracleLob GetOracleLob(int i)
@@ -757,6 +757,27 @@ namespace System.Data.OracleClient
                     return value;
                 default:
                     return defineHandle.GetValue(command.Connection.SessionFormatProvider, command.Connection);
+            }
+        }
+
+        public
+        object GetValueByteArray(int i)
+        {
+            OciDefineHandle defineHandle = (OciDefineHandle)statement.Values[i];
+
+            if (defineHandle.IsNull)
+                return DBNull.Value;
+
+            switch (defineHandle.DataType)
+            {
+                case OciDataType.Blob:
+                case OciDataType.Clob:
+                    OracleLob lob = GetOracleLob(i);
+                    object value = lob.Value;
+                    lob.Close();
+                    return value;
+                default:
+                    return defineHandle.GetValueByteArray(command.Connection);
             }
         }
 

--- a/src/dotNetCore.Data.OracleClient/dotNetCore.Data.OracleClient.csproj
+++ b/src/dotNetCore.Data.OracleClient/dotNetCore.Data.OracleClient.csproj
@@ -4,12 +4,16 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>dotNetCore.Data.OracleClient</PackageId>
     <Product>oracleClientCore-2.0</Product>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>Eric Mendonca</Authors>
     <PackageProjectUrl>https://github.com/ericmend/oracleClientCore-2.0</PackageProjectUrl>
     <Description>Unofficial Oracle Client for .Net Core</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>
+      1.0.1
+      - Better handling of binary data in varchar fields.
+      - Method to (mostly) build a self contained NuGet package.
+
       1.0.0
       - Providing the unofficial oracle client as nuget
       </PackageReleaseNotes>


### PR DESCRIPTION
First, thank you for this library. I am stuck using an old (9i) instance of Oracle and the new official dotnet core driver does not and will not support such an old database. (I asked Oracle on twitter about such support and they confirmed only 11+) This library has saved me a lot of headache.

This same instance abuses varchar and long fields by putting binary data into the fields. Sometimes they are all nulls e.g. a sequence of 16 zeros), and sometimes lots of other non-ASCII and non-unicode data. This is also done with a LONG field so using RAWTOHEX on such field is not a possible workaround.

Currently, when getting a byte-array with this library, it first converts a varchar field to a (unicode) string and then back to a byte array. With binary data, this causes problems either when the field is all nulls, or as loss of data from invalid/incorrectly interpreted unicode sequences.

This pull request fixes that issue by keeping the backing data a byte array. With it, I can get the binary data out of the oracle varchar fields.

This pull request and all changes to the effected files that are part of this pull request are licensed the same as this library.

Thank you.

--Bill


